### PR TITLE
Fix USB support for Android 14+ and improve device identification

### DIFF
--- a/android/src/main/java/com/pinmi/react/printer/adapter/USBPrinterAdapter.java
+++ b/android/src/main/java/com/pinmi/react/printer/adapter/USBPrinterAdapter.java
@@ -120,7 +120,12 @@ public class USBPrinterAdapter implements PrinterAdapter {
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
         filter.addAction(UsbManager.ACTION_USB_ACCESSORY_ATTACHED);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
-        mContext.registerReceiver(mUsbDeviceReceiver, filter);
+        if (android.os.Build.VERSION.SDK_INT >= 33) {
+            // API 33+ requires RECEIVER_NOT_EXPORTED (value 4) or RECEIVER_EXPORTED flag
+            mContext.registerReceiver(mUsbDeviceReceiver, filter, 4);
+        } else {
+            mContext.registerReceiver(mUsbDeviceReceiver, filter);
+        }
         Log.v(LOG_TAG, "RNUSBPrinter initialized");
         successCallback.invoke();
     }

--- a/android/src/main/java/com/pinmi/react/printer/adapter/USBPrinterDevice.java
+++ b/android/src/main/java/com/pinmi/react/printer/adapter/USBPrinterDevice.java
@@ -1,8 +1,10 @@
 package com.pinmi.react.printer.adapter;
 
+import android.hardware.usb.UsbConstants;
 import android.hardware.usb.UsbDevice;
 
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 
 /**
@@ -36,9 +38,19 @@ public class USBPrinterDevice implements PrinterDevice{
         deviceMap.putInt("vendor_id", this.mDevice.getVendorId());
         deviceMap.putInt("product_id", this.mDevice.getProductId());
         String productName = this.mDevice.getProductName();
-        String manufacturerName = this.mDevice.getManufacturerName();
         deviceMap.putString("product_name", productName != null ? productName : "");
-        deviceMap.putString("manufacturer_name", manufacturerName != null ? manufacturerName : "");
+        deviceMap.putInt("device_class", this.mDevice.getDeviceClass());
+        boolean isPrinterClass = this.mDevice.getDeviceClass() == UsbConstants.USB_CLASS_PRINTER;
+        WritableArray interfaceClasses = Arguments.createArray();
+        for (int i = 0; i < this.mDevice.getInterfaceCount(); i++) {
+            int ifaceClass = this.mDevice.getInterface(i).getInterfaceClass();
+            interfaceClasses.pushInt(ifaceClass);
+            if (ifaceClass == UsbConstants.USB_CLASS_PRINTER) {
+                isPrinterClass = true;
+            }
+        }
+        deviceMap.putBoolean("is_printer_class", isPrinterClass);
+        deviceMap.putArray("interface_classes", interfaceClasses);
         return deviceMap;
     }
 

--- a/android/src/main/java/com/pinmi/react/printer/adapter/USBPrinterDevice.java
+++ b/android/src/main/java/com/pinmi/react/printer/adapter/USBPrinterDevice.java
@@ -35,6 +35,10 @@ public class USBPrinterDevice implements PrinterDevice{
         deviceMap.putInt("device_id", this.mDevice.getDeviceId());
         deviceMap.putInt("vendor_id", this.mDevice.getVendorId());
         deviceMap.putInt("product_id", this.mDevice.getProductId());
+        String productName = this.mDevice.getProductName();
+        String manufacturerName = this.mDevice.getManufacturerName();
+        deviceMap.putString("product_name", productName != null ? productName : "");
+        deviceMap.putString("manufacturer_name", manufacturerName != null ? manufacturerName : "");
         return deviceMap;
     }
 


### PR DESCRIPTION
## Summary

- Fix `registerReceiver` crash on Android 14+ (API 33+) by passing `RECEIVER_NOT_EXPORTED` flag when registering the USB broadcast receiver
- Expose `product_name`, `device_class`, `is_printer_class`, and `interface_classes` in the USB device map to allow the frontend to identify printer devices by USB class codes and displaying more reasonable names.